### PR TITLE
Removed python update to unsupported version

### DIFF
--- a/docker/bin/container-install-prereqs.sh
+++ b/docker/bin/container-install-prereqs.sh
@@ -29,8 +29,6 @@ apt-get install -qy \
   less \
   lsb-release \
   nano \
-  python3 \
-  python3-pip \
   tzdata \
   unzip \
   vim \


### PR DESCRIPTION
Prevented python from being updated to the latest version instead of staying at the supported 3.8 version.

# Description

**Make sure the PR is against the `develop` branch (see [Contributing](https://github.com/nccgroup/ScoutSuite/blob/master/CONTRIBUTING.md)).**

**Make sure to set the corresponding milestone in the PR.**

Please include a summary of the change(s) and which issue(s) it addresses. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change

Select the relevant option(s):

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
